### PR TITLE
Add an extension method to return a deserialised object from stored JSON representation

### DIFF
--- a/NReJSON.IntegrationTests/DatabaseExtensionAsyncTests.cs
+++ b/NReJSON.IntegrationTests/DatabaseExtensionAsyncTests.cs
@@ -1,4 +1,6 @@
-﻿using StackExchange.Redis;
+﻿using Newtonsoft.Json;
+using NReJSON.IntegrationTests.TestTypes;
+using StackExchange.Redis;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -30,9 +32,33 @@ namespace NReJSON.IntegrationTests
 
                 await _db.JsonSetAsync(key, "{\"hello\": \"world\", \"goodnight\": {\"value\": \"moon\"}}");
 
-                var result = await _db.JsonGetAsync("test_get_object");
+                var result = await _db.JsonGetAsync(key);
 
                 Assert.False(result.IsNull);
+            }
+
+            [Fact]
+            public async Task CanReturnDeserialisedObjectFromJsonAsync()
+            {
+                var customerToSave = new Customer
+                {
+                    Id = 12345,
+                    Name = "XYZ Inc.",
+                    RegisteredOn = DateTime.UtcNow,
+                    CorporateAddress = new Address
+                    {
+                        City = "London",
+                        Postcode = "NW1"
+                    }
+                };
+
+                await _db.JsonSetAsync(
+                    customerToSave.Id.ToString(),
+                    JsonConvert.SerializeObject(customerToSave));
+
+                var savedCustomer = await _db.JsonGetAsync<Customer>(
+                    customerToSave.Id.ToString());
+                Assert.True(savedCustomer.Equals(customerToSave));
             }
         }
 

--- a/NReJSON.IntegrationTests/DatabaseExtensionTests.cs
+++ b/NReJSON.IntegrationTests/DatabaseExtensionTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Linq;
+using Newtonsoft.Json;
+using NReJSON.IntegrationTests.TestTypes;
 using StackExchange.Redis;
 using Xunit;
 
@@ -29,9 +31,33 @@ namespace NReJSON.IntegrationTests
 
                 _db.JsonSet(key, "{\"hello\": \"world\", \"goodnight\": {\"value\": \"moon\"}}");
 
-                var result = _db.JsonGet("test_get_object");
+                var result = _db.JsonGet(key);
 
                 Assert.False(result.IsNull);
+            }
+
+            [Fact]
+            public void CanReturnDeserialisedObjectFromJson()
+            {
+                var customerToSave = new Customer
+                {
+                    Id = 1234,
+                    Name = "XYZ Inc.",
+                    RegisteredOn = DateTime.UtcNow,
+                    CorporateAddress = new Address
+                    {
+                        City = "London",
+                        Postcode = "NW1"
+                    }
+                };
+
+                _db.JsonSet(
+                    customerToSave.Id.ToString(), 
+                    JsonConvert.SerializeObject(customerToSave));
+
+                var savedCustomer = _db.JsonGet<Customer>(
+                    customerToSave.Id.ToString());
+                Assert.True(savedCustomer.Equals(customerToSave));
             }
         }
 

--- a/NReJSON.IntegrationTests/TestTypes/Address.cs
+++ b/NReJSON.IntegrationTests/TestTypes/Address.cs
@@ -1,0 +1,9 @@
+﻿namespace NReJSON.IntegrationTests.TestTypes
+{
+    public struct Address
+    {
+        public string City { get; set; }
+
+        public string Postcode { get; set; }
+    }
+}

--- a/NReJSON.IntegrationTests/TestTypes/Customer.cs
+++ b/NReJSON.IntegrationTests/TestTypes/Customer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace NReJSON.IntegrationTests.TestTypes
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime RegisteredOn { get; set; }
+
+        public Address CorporateAddress { get; set; }
+
+        public override bool Equals(object obj) =>
+            this.GetHashCode() == obj.GetHashCode();
+
+        public override int GetHashCode() =>
+            new
+            {
+                Id,
+                Name,
+                RegisteredOn,
+                CorporateAddress
+            }.GetHashCode();
+    }
+}

--- a/NReJSON.Tests/DatabaseExtensionsAsyncTests.cs
+++ b/NReJSON.Tests/DatabaseExtensionsAsyncTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using Newtonsoft.Json;
+using NReJSON.Tests.TestTypes;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace NReJSON.Tests
@@ -58,6 +61,33 @@ namespace NReJSON.Tests
                 await db.JsonGetAsync("fake_key", false);
 
                 Assert.Equal(new[] { "JSON.GET", "fake_key", "." }, db.PreviousCommand);
+            }
+
+            [Fact]
+            public void CanReturnDeserialisedObjectFromJson()
+            {
+                var customerToSave = new Customer
+                {
+                    Id = 1234,
+                    Name = "XYZ Inc.",
+                    RegisteredOn = DateTime.UtcNow,
+                    CorporateAddress = new Address
+                    {
+                        City = "London",
+                        Postcode = "NW1"
+                    }
+                };
+
+                var expectedJson = JsonConvert.SerializeObject(customerToSave);
+                var db = new FakeDatabase(expectedJson);
+
+                db.JsonSet(
+                    customerToSave.Id.ToString(),
+                    expectedJson);
+
+                var savedCustomer = db.JsonGet<Customer>(
+                    customerToSave.Id.ToString());
+                Assert.True(savedCustomer.Equals(customerToSave));
             }
         }
 

--- a/NReJSON.Tests/DatabaseExtensionsTests.cs
+++ b/NReJSON.Tests/DatabaseExtensionsTests.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+﻿using Newtonsoft.Json;
+using NReJSON.Tests.TestTypes;
+using System;
+using Xunit;
 
 namespace NReJSON.Tests
 {
@@ -57,6 +60,33 @@ namespace NReJSON.Tests
                 db.JsonGet("fake_key", false);
 
                 Assert.Equal(new[] { "JSON.GET", "fake_key", "." }, db.PreviousCommand);
+            }
+
+            [Fact]
+            public void CanReturnDeserialisedObjectFromJson()
+            {
+                var customerToSave = new Customer
+                {
+                    Id = 1234,
+                    Name = "XYZ Inc.",
+                    RegisteredOn = DateTime.UtcNow,
+                    CorporateAddress = new Address
+                    {
+                        City = "London",
+                        Postcode = "NW1"
+                    }
+                };
+
+                var expectedJson = JsonConvert.SerializeObject(customerToSave);
+                var db = new FakeDatabase(expectedJson);
+
+                db.JsonSet(
+                    customerToSave.Id.ToString(),
+                    expectedJson);
+
+                var savedCustomer = db.JsonGet<Customer>(
+                    customerToSave.Id.ToString());
+                Assert.True(savedCustomer.Equals(customerToSave));
             }
         }
 

--- a/NReJSON.Tests/FakeDatabase.cs
+++ b/NReJSON.Tests/FakeDatabase.cs
@@ -8,12 +8,20 @@ namespace NReJSON.Tests
 {
     public class FakeDatabase : IDatabase
     {
+        private readonly RedisValue _expectedValue;
         private bool _expectArrayResult;
 
         public string[] PreviousCommand { get; private set; }
 
-        public FakeDatabase(bool expectArrayResult = false) =>
+        public FakeDatabase(RedisValue expectedValue) : this()
+        {
+            _expectedValue = expectedValue;
+        }
+
+        public FakeDatabase(bool expectArrayResult = false)
+        {
             _expectArrayResult = expectArrayResult;
+        }
 
         public RedisResult Execute(string command, params object[] args)
         {
@@ -32,7 +40,8 @@ namespace NReJSON.Tests
             }
             else
             {
-                return RedisResult.Create(0);
+                return RedisResult.Create(
+                    _expectedValue.HasValue ? _expectedValue : 0);
             }
         }
 

--- a/NReJSON.Tests/TestTypes/Address.cs
+++ b/NReJSON.Tests/TestTypes/Address.cs
@@ -1,0 +1,9 @@
+﻿namespace NReJSON.Tests.TestTypes
+{
+    public struct Address
+    {
+        public string City { get; set; }
+
+        public string Postcode { get; set; }
+    }
+}

--- a/NReJSON.Tests/TestTypes/Customer.cs
+++ b/NReJSON.Tests/TestTypes/Customer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace NReJSON.Tests.TestTypes
+{
+    public class Customer
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public DateTime RegisteredOn { get; set; }
+
+        public Address CorporateAddress { get; set; }
+
+        public override bool Equals(object obj) =>
+            this.GetHashCode() == obj.GetHashCode();
+
+        public override int GetHashCode() =>
+            new
+            {
+                Id,
+                Name,
+                RegisteredOn,
+                CorporateAddress
+            }.GetHashCode();
+    }
+}

--- a/NReJSON/DatabaseExtensions.cs
+++ b/NReJSON/DatabaseExtensions.cs
@@ -1,4 +1,5 @@
-﻿using StackExchange.Redis;
+﻿using Newtonsoft.Json;
+using StackExchange.Redis;
 using System;
 using System.Linq;
 
@@ -396,5 +397,16 @@ namespace NReJSON
         /// <returns>Array, specifically the JSON's RESP form as detailed.</returns>
         public static RedisResult[] JsonGetResp(this IDatabase db, RedisKey key, string path = ".") =>
             (RedisResult[])db.Execute(JsonCommands.RESP, key, path);
+
+        /// <summary>
+        /// Returns the strongly typed object for the stored JSON type.
+        /// This method returns all the properties of the JSON document
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="db"></param>
+        /// <param name="key">The key of the JSON object that you want an JSON.GET result for.</param>
+        /// <returns><see cref="TEntity"/></returns>
+        public static TEntity JsonGet<TEntity>(this IDatabase db, RedisKey key) where TEntity: class =>
+            JsonConvert.DeserializeObject<TEntity>(db.JsonGet(key).ToString());
     }
 }

--- a/NReJSON/DatabaseExtensionsAsync.cs
+++ b/NReJSON/DatabaseExtensionsAsync.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using StackExchange.Redis;
 using System;
 using System.Linq;
@@ -396,5 +397,16 @@ namespace NReJSON
         /// <returns>Array, specifically the JSON's RESP form as detailed.</returns>
         public static async Task<RedisResult[]> JsonGetRespAsync(this IDatabase db, RedisKey key, string path = ".") =>
             (RedisResult[])(await db.ExecuteAsync(JsonCommands.RESP, key, path));
+
+        /// <summary>
+        /// Returns the strongly typed object for the stored JSON type.
+        /// This method returns all the properties of the JSON document
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <param name="db"></param>
+        /// <param name="key">The key of the JSON object that you want an JSON.GET result for.</param>
+        /// <returns><see cref="Task{TEntity}"/></returns>
+        public static async Task<TEntity> JsonGetAsync<TEntity>(this IDatabase db, RedisKey key) where TEntity : class =>
+            JsonConvert.DeserializeObject<TEntity>((await db.JsonGetAsync(key)).ToString());
     }
 }

--- a/NReJSON/NReJSON.csproj
+++ b/NReJSON/NReJSON.csproj
@@ -5,9 +5,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Tom Hanks</Authors>
     <Company />
-    <AssemblyVersion>0.0.1.0</AssemblyVersion>
-    <FileVersion>0.0.1.0</FileVersion>
-    <Version>0.0.1</Version>
+    <AssemblyVersion>0.1.0.0</AssemblyVersion>
+    <FileVersion>0.1.0.0</FileVersion>
+    <Version>0.1.0</Version>
     <Description>A series of extension methods for use with StackExchange.Redis 2.x and the ReJSON Redis module.</Description>
     <PackageLicenseUrl>https://mit-license.org/; https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.519" />
   </ItemGroup>
 


### PR DESCRIPTION
First of all a big **thank you** for this useful package, saved me a tonne of work having to create something similar myself. Please let me know if I've missed something that you'd like to see in PRs for this repo in general, I understand each repository has different standards.

This PR adds a new extension method (both sync and async variants) that returns a strongly typed deserialised object from the stored JSON value in Redis. This method is essentially a convenience extension over the existing API so its backward compatible.

Usage:

```
var customer = await redis.GetDatabase().JsonGetAsync<Customer>("some_key");
```
This PR also fixes 2 integration tests that were trying to retrieve values for a different key to the one that the value was saved with, resulting in failing tests. 