### PR TITLE
`JSON.STRAPPEND` Implementation

### DIFF
--- a/NReJSON.IntegrationTests/DatabaseExtensionAsyncTests.cs
+++ b/NReJSON.IntegrationTests/DatabaseExtensionAsyncTests.cs
@@ -215,16 +215,44 @@ namespace NReJSON.IntegrationTests
 
         public class JsonAppendJsonStringAsync : BaseIntegrationTest
         {
-            [Fact(Skip = "This doesn't work, not sure what I'm doing wrong yet.")]
+            [Fact]
             public async Task CanExecuteAsync()
             {
                 var key = Guid.NewGuid().ToString("N");
 
                 await _db.JsonSetAsync(key, "{\"hello\":\"world\"}");
 
-                var result = await _db.JsonAppendJsonStringAsync(key, ".hello", "{\"t\":1}");
+                var result = await _db.JsonAppendJsonStringAsync(key, ".hello", "\"!\"");
 
-                Assert.Equal(4, result);
+                Assert.Equal(6, result);
+            }
+
+            [Fact]
+            public async Task WillAppendProvidedJsonStringIntoExistingJsonString()
+            {
+                var key = Guid.NewGuid().ToString("N");
+
+                await _db.JsonSetAsync(key, "{\"hello\":\"world\"}");
+
+                await _db.JsonAppendJsonStringAsync(key, ".hello", "\"!\"");
+
+                var helloValue = await _db.JsonGetAsync<string>(key, ".hello");
+
+                Assert.Equal("world!", helloValue);
+            }
+
+            [Fact]
+            public async Task WillApendProvidedJsonStringIntoRootIfNoPathProvided()
+            {
+                var key = Guid.NewGuid().ToString("N");
+
+                await _db.JsonSetAsync(key, "\"world\"");
+
+                await _db.JsonAppendJsonStringAsync(key, jsonString: "\"!\"");
+
+                var helloValue = await _db.JsonGetAsync<string>(key);
+
+                Assert.Equal("world!", helloValue);
             }
         }
 

--- a/NReJSON.IntegrationTests/DatabaseExtensionTests.cs
+++ b/NReJSON.IntegrationTests/DatabaseExtensionTests.cs
@@ -215,16 +215,44 @@ namespace NReJSON.IntegrationTests
 
         public class JsonAppendJsonString : BaseIntegrationTest
         {
-            [Fact(Skip = "This doesn't work, not sure what I'm doing wrong yet.")]
-            public void ItCanAppendJsonString()
+            [Fact]
+            public void CanExecuteAsync()
             {
                 var key = Guid.NewGuid().ToString("N");
 
                 _db.JsonSet(key, "{\"hello\":\"world\"}");
 
-                var result = _db.JsonAppendJsonString(key, ".hello", "{\"t\":1}");
+                var result = _db.JsonAppendJsonString(key, ".hello", "\"!\"");
 
-                Assert.Equal(4, result);
+                Assert.Equal(6, result);
+            }
+
+            [Fact]
+            public void WillAppendProvidedJsonStringIntoExistingJsonString()
+            {
+                var key = Guid.NewGuid().ToString("N");
+
+                _db.JsonSet(key, "{\"hello\":\"world\"}");
+
+                _db.JsonAppendJsonString(key, ".hello", "\"!\"");
+
+                var helloValue = _db.JsonGet<string>(key, ".hello");
+
+                Assert.Equal("world!", helloValue);
+            }
+            
+            [Fact]
+            public void WillApendProvidedJsonStringIntoRootIfNoPathProvided()
+            {
+                var key = Guid.NewGuid().ToString("N");
+
+                _db.JsonSet(key, "\"world\"");
+
+                _db.JsonAppendJsonString(key, jsonString: "\"!\"");
+
+                var helloValue = _db.JsonGet<string>(key);
+
+                Assert.Equal("world!", helloValue);
             }
         }
 

--- a/NReJSON.Tests/DatabaseExtensionsAsyncTests.cs
+++ b/NReJSON.Tests/DatabaseExtensionsAsyncTests.cs
@@ -248,7 +248,25 @@ namespace NReJSON.Tests
 
         public class JsonAppendJsonStringAsync
         {
-            // TODO: Complete this once I figure out how this command is supposed to work.
+            [Fact]
+            public async Task EmitsCorrectParameters()
+            {
+                var db = new FakeDatabase();
+
+                await db.JsonAppendJsonStringAsync("fake_key", ".fake.path", "\"fake_string\"");
+
+                Assert.Equal(new[] { "JSON.STRAPPEND", "fake_key", ".fake.path", "\"fake_string\"" }, db.PreviousCommand);
+            }
+            
+            [Fact]
+            public async Task HasRootAsDefaultPath()
+            {
+                var db = new FakeDatabase();
+
+                await db.JsonAppendJsonStringAsync("fake_key", jsonString: "\"fake_string\"");
+
+                Assert.Equal(new[] { "JSON.STRAPPEND", "fake_key", ".", "\"fake_string\"" }, db.PreviousCommand);
+            }
         }
 
         public class JsonStringLengthAsync

--- a/NReJSON.Tests/DatabaseExtensionsTests.cs
+++ b/NReJSON.Tests/DatabaseExtensionsTests.cs
@@ -247,7 +247,25 @@ namespace NReJSON.Tests
 
         public class JsonAppendJsonString
         {
-            // TODO: Complete this once I figure out how this command is supposed to work.
+            [Fact]
+            public void EmitsCorrectParameters()
+            {
+                var db = new FakeDatabase();
+
+                db.JsonAppendJsonString("fake_key", ".fake.path", "\"fake_string\"");
+
+                Assert.Equal(new[] { "JSON.STRAPPEND", "fake_key", ".fake.path", "\"fake_string\"" }, db.PreviousCommand);
+            }
+            
+            [Fact]
+            public void HasRootAsDefaultPath()
+            {
+                var db = new FakeDatabase();
+
+                db.JsonAppendJsonString("fake_key", jsonString: "\"fake_string\"");
+
+                Assert.Equal(new[] { "JSON.STRAPPEND", "fake_key", ".", "\"fake_string\"" }, db.PreviousCommand);
+            }
         }
 
         public class JsonStringLength

--- a/NReJSON/DatabaseExtensions.cs
+++ b/NReJSON/DatabaseExtensions.cs
@@ -279,24 +279,20 @@ namespace NReJSON
             db.Execute(JsonCommands.NUMMULTBY, CombineArguments(key, path, number));
 
         /// <summary>
-        /// [Not implemented yet]
-        /// 
         /// `JSON.STRAPPEND`
         /// 
         /// Append the json-string value(s) the string at path.
-        ///
         /// path defaults to root if not provided.
         /// 
         /// https://oss.redislabs.com/rejson/commands/#jsonstrappend
         /// </summary>
         /// <param name="db"></param>
-        /// <param name="key"></param>
-        /// <param name="path"></param>
+        /// <param name="key">The key of the JSON object you need to append a string value.</param>
+        /// <param name="path">The path of the JSON string you want to append do.  This defaults to root.</param>
         /// <param name="jsonString"></param>
-        /// <returns>Length of the new JSON object.</returns>
-        public static int JsonAppendJsonString(this IDatabase db, RedisKey key, string path = ".", string jsonString = "{}") =>
-            //(int)db.Execute(GetCommandName(CommandType.Json.STRAPPEND), CombineArguments(key, path, jsonString));
-            throw new NotImplementedException("This doesn't work, not sure what I'm doing wrong here.");
+        /// <returns>Length of the new JSON string.</returns>
+        public static int JsonAppendJsonString(this IDatabase db, RedisKey key, string path = ".", string jsonString = "\"\"") =>
+            (int)db.Execute(JsonCommands.STRAPPEND, CombineArguments(key, path, jsonString));
 
         /// <summary>
         /// `JSON.STRLEN`

--- a/NReJSON/DatabaseExtensionsAsync.cs
+++ b/NReJSON/DatabaseExtensionsAsync.cs
@@ -284,23 +284,20 @@ namespace NReJSON
             db.ExecuteAsync(JsonCommands.NUMMULTBY, CombineArguments(key, path, number));
 
         /// <summary>
-        /// [Not implemented yet]
-        /// 
         /// `JSON.STRAPPEND`
         /// 
         /// Append the json-string value(s) the string at path.
-        ///
         /// path defaults to root if not provided.
         /// 
         /// https://oss.redislabs.com/rejson/commands/#jsonstrappend
         /// </summary>
         /// <param name="db"></param>
-        /// <param name="key">The key of the JSON object you want to append to.</param>
-        /// <param name="path"></param>
+        /// <param name="key">The key of the JSON object you need to append a string value.</param>
+        /// <param name="path">The path of the JSON string you want to append do. This defaults to root.</param>
         /// <param name="jsonString"></param>
-        /// <returns>Length of the new JSON object.</returns>
-        public static Task<int> JsonAppendJsonStringAsync(this IDatabase db, RedisKey key, string path = ".", string jsonString = "{}") =>
-            throw new NotImplementedException("This doesn't work, not sure what I'm doing wrong here.");
+        /// <returns>Length of the new JSON string.</returns>
+        public static async Task<int> JsonAppendJsonStringAsync(this IDatabase db, RedisKey key, string path = ".", string jsonString = "\"\"") =>
+            (int)(await db.ExecuteAsync(JsonCommands.STRAPPEND, CombineArguments(key, path, jsonString)));
 
         /// <summary>
         /// `JSON.STRLEN`


### PR DESCRIPTION
This PR adds a simple and straightforward implementation of `JSON.STRAPPEND`. It just does what it was meant to.

The existing API will definitely confuse developers once they'll encounter that they need to serialize a string prior to calling this API. :)
So maybe the desired implementation is to translate basic strings into JSON strings implicitly.